### PR TITLE
Fix: White Space in folder threw Error

### DIFF
--- a/src/dnu.js
+++ b/src/dnu.js
@@ -40,7 +40,7 @@ function run(cmd, options) {
   var args = [];
   var command = commands();
   projects.forEach(function (project) {
-    if (windows) project = project.replace(/\//g, '\\');
+    if (windows) project = '"' + project.replace(/\//g, '\\') + '"';
     args.push(command(cmd, options, project).join(' '));
   });
 


### PR DESCRIPTION
Fixed bug where space in folder name caused error in Windows. Added double quotes when resolving path.